### PR TITLE
Fix syntax highlighting and remove !important from pre background

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -70,6 +70,11 @@ unsafe = true
 
 [markup]
 
+  # Syntax highlighting - use CSS classes instead of inline styles
+  # This allows the theme's base16 colors to control syntax highlighting
+  [markup.highlight]
+    noClasses = false
+
   # Table of contents
   # Add toc = true to content front matter to enable
   [markup.tableOfContents]

--- a/static/css/typography.css
+++ b/static/css/typography.css
@@ -147,7 +147,7 @@ pre,
 code, 
 kbd,
 samp {
-    background: var(--inner-bg) !important;
+    background: var(--inner-bg);
     font-family: var(--font-monospace);
     color: var(--off-fg);
 }
@@ -162,6 +162,143 @@ pre {
 /* See https://github.com/joeroe/risotto/issues/41 */
 .highlight div {
 	overflow-x: auto;
+}
+
+/* Comprehensive Chroma syntax highlighting using Risotto's base16 colors */
+/* Background */
+.chroma {
+  background-color: var(--inner-bg);
+  color: var(--fg);
+}
+/* Error */
+.chroma .err {
+  color: var(--fg);
+  background-color: var(--base08);
+}
+/* LineLink */
+.chroma .lnlinks {
+  outline: none;
+  text-decoration: none;
+  color: inherit;
+}
+/* LineTableTD */
+.chroma .lntd {
+  vertical-align: top;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+/* LineTable */
+.chroma .lntable {
+  border-spacing: 0;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+/* LineHighlight */
+.chroma .hl {
+  background-color: var(--off-bg);
+}
+/* LineNumbersTable */
+.chroma .lnt {
+  white-space: pre;
+  -webkit-user-select: none;
+  user-select: none;
+  margin-right: 0.4em;
+  padding: 0 0.4em;
+  color: var(--muted);
+}
+/* LineNumbers */
+.chroma .ln {
+  white-space: pre;
+  -webkit-user-select: none;
+  user-select: none;
+  margin-right: 0.4em;
+  padding: 0 0.4em;
+  color: var(--muted);
+}
+/* Line */
+.chroma .line {
+  display: flex;
+}
+/* Keywords - Purple */
+.chroma .k { color: var(--base0E); }
+.chroma .kc { color: var(--base0E); }
+.chroma .kd { color: var(--base0E); }
+.chroma .kn { color: var(--base0E); }
+.chroma .kp { color: var(--base0E); }
+.chroma .kr { color: var(--base0E); }
+.chroma .kt { color: var(--base0E); }
+/* Names and identifiers - Red */
+.chroma .na { color: var(--base08); }
+.chroma .nc { color: var(--base08); }
+.chroma .no { color: var(--base09); }
+.chroma .nd { color: var(--base0D); }
+.chroma .ni { color: var(--base08); }
+.chroma .nl { color: var(--base08); font-weight: bold; }
+.chroma .nn { color: var(--base08); }
+.chroma .nx { color: var(--fg); }
+.chroma .nt { color: var(--base08); }
+/* Built-ins - Yellow */
+.chroma .nb { color: var(--base0A); }
+.chroma .bp { color: var(--base0A); }
+/* Variables - Red */
+.chroma .nv { color: var(--base08); }
+.chroma .vc { color: var(--base08); }
+.chroma .vg { color: var(--base08); }
+.chroma .vi { color: var(--base08); }
+.chroma .vm { color: var(--base08); }
+/* Functions - Blue */
+.chroma .nf { color: var(--base0D); }
+.chroma .fm { color: var(--base0D); }
+/* Strings - Green */
+.chroma .s { color: var(--base0B); }
+.chroma .sa { color: var(--base0B); }
+.chroma .sb { color: var(--base0B); }
+.chroma .sc { color: var(--base0B); }
+.chroma .dl { color: var(--base0B); }
+.chroma .sd { color: var(--off-fg); }
+.chroma .s2 { color: var(--base0B); }
+.chroma .se { color: var(--base0C); }
+.chroma .sh { color: var(--base0B); }
+.chroma .si { color: var(--base0C); }
+.chroma .sx { color: var(--base0B); }
+.chroma .sr { color: var(--base0C); }
+.chroma .s1 { color: var(--base0B); }
+.chroma .ss { color: var(--base0C); }
+/* Numbers - Orange */
+.chroma .m { color: var(--base09); }
+.chroma .mb { color: var(--base09); }
+.chroma .mf { color: var(--base09); }
+.chroma .mh { color: var(--base09); }
+.chroma .mi { color: var(--base09); }
+.chroma .il { color: var(--base09); }
+.chroma .mo { color: var(--base09); }
+/* Operators - Cyan */
+.chroma .o { color: var(--base0C); }
+.chroma .ow { color: var(--base0E); }
+/* Punctuation - Default */
+.chroma .p { color: var(--fg); }
+/* Comments - Muted */
+.chroma .c { color: var(--off-fg); }
+.chroma .ch { color: var(--off-fg); }
+.chroma .cm { color: var(--off-fg); }
+.chroma .c1 { color: var(--off-fg); }
+.chroma .cs { color: var(--off-fg); }
+.chroma .cp { color: var(--base0E); }
+.chroma .cpf { color: var(--base0E); }
+/* GenericDeleted */
+.chroma .gd { color: var(--base08); background-color: var(--off-bg); }
+/* GenericEmph */
+.chroma .ge { font-style: italic; }
+/* GenericInserted */
+.chroma .gi { color: var(--base0B); background-color: var(--off-bg); }
+/* GenericOutput */
+.chroma .go { color: var(--fg); }
+/* GenericUnderline */
+.chroma .gl { text-decoration: underline; }
+/* TextWhitespace */
+.chroma .w { color: var(--muted); }
 }
 
 /* Emphasis */


### PR DESCRIPTION
## Summary

This PR fixes the CSS `!important` usage in syntax highlighting that was interfering with custom shortcodes, while maintaining full Hugo highlight support. **This is a breaking change** that requires users to update their Hugo configuration.

## Background & Research

The `!important` rule was originally added in commit [e9cfcaf](https://github.com/joeroe/risotto/commit/e9cfcaf94c72a3231d2d68e12efe1c48f7c06f79) by @mntn-xyz to fix a Hugo syntax highlighting issue:

> "When using code highlighting, the generated Hugo styles replace the <pre> background color, making the page look ugly (only the text has a background, not the entire <pre> block). Setting the background !important fixes this. This is not ideal, but the styles are applied directly to the element when using the internal highlight shortcode, so this is the only way to override them."

### The Original Problem
Hugo's syntax highlighting was generating inline styles like:
```html
<pre style="color:#f8f8f2;background-color:#272822;...">
```

These inline styles have higher specificity than CSS classes, overriding the theme's `background: var(--inner-bg)` rule and causing visual inconsistencies.

### Why !important Became Problematic
While the `!important` solved Hugo's inline style issue, it created a new problem: it prevented custom shortcodes from overriding the background color, breaking components that needed different styling (like terminal shortcodes using `var(--base00)`).

## The Solution

This PR takes a different approach by configuring Hugo to generate **CSS classes instead of inline styles**, eliminating the need for `!important`. However, this requires users to update their Hugo configuration.

## Breaking Change

**Users must add this to their `config.toml`:**
```toml
[markup.highlight]
  noClasses = false
```

Without this configuration change, syntax highlighting will revert to Hugo's default inline styles and may not display correctly with the theme colors.

## Changes Made

### `static/css/typography.css`
- **Line 150**: Removed `!important` from `background: var(--inner-bg)`
- **Lines 167-301**: Added comprehensive Chroma syntax highlighting with 70+ token classes using base16 variables

### `exampleSite/config.toml`
- **Lines 75-76**: Added Hugo markup configuration to generate CSS classes instead of inline styles

## Before vs After

**Before**:
```html
<pre style="background-color:#272822">  <!-- Hard-coded color, !important needed -->
```

**After**:
```html  
<pre class="chroma">  <!-- Uses theme's base16 colors -->
```

## Benefits

- **Reduced !important usage** - CSS classes have proper specificity  
- **Respects color schemes** - Automatically adapts to any base16 palette  
- **Won't interfere with custom shortcodes** - Only targets `.chroma` classes  
- **Comprehensive syntax highlighting** - All token types properly styled  
- **Maintainable** - Uses existing base16 variable system  

## Testing

We've been using this approach in our fork and it works well:
- [x] Hugo highlight shortcode works correctly with theme colors
- [x] Regular indented code blocks still work  
- [x] No visual regressions in syntax highlighting
- [x] Custom shortcodes can now override background colors without conflicts

This approach reduces the need for `!important` while maintaining all existing functionality, but does require the configuration update noted above.